### PR TITLE
Add a basic GitHub Actions workflow

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,1 +1,3 @@
 ^LICENSE\.md$
+^\.git$
+^\.github$

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,28 @@
+name: CI
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+jobs:
+  build-and-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+      - name: Build and check
+        uses: r-lib/actions/check-r-package@v2
+        with:
+          error-on: '"error"'


### PR DESCRIPTION
.github/workflows/ci.yaml uses the r-lib/actions/setup-r action to install the most recent R release, then uses
r-lib/actions/setup-r-dependencies to install the package's R dependencies and finally runs R CMD build and R CMD check with r-lib/actions/check-r-package.

rcmdcheck is needed as an extra package for check-r-package.

check-r-package only fails on R CMD check errors. There are a few extant warnings, which will be fixed in a future commit.

.Rbuildignore is updated to ignore both the new .github directory and .git, which was causing a NOTE on R CMD check.