### PR TITLE
Fix warnings from R CMD check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,5 +26,3 @@ jobs:
           extra-packages: any::rcmdcheck
       - name: Build and check
         uses: r-lib/actions/check-r-package@v2
-        with:
-          error-on: '"error"'

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,0 @@
-#' @noRd
-dummy <- function() {
-	remotes::available_packages()
-}


### PR DESCRIPTION
This will fix #5

R/utils.R is deleted, since that function doesn't do anything.

R/has_topotoolbox.R adds documentation of the parameter a

man/has_topotoolbox.Rd is the auto-generated documentation for has_topotoolbox

The warnings have been fixed, so I have restored the default setting for check-r-package, which fails on warnings and errors.

@FancyBirb: This PR messes with some of your R code, so I'd like your review of the changes before I merge it.