### PR TITLE
Integrate libtopotoolbox

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,6 @@
 ^LICENSE\.md$
 ^\.git$
 ^\.github$
+^src/libs/libtopotoolbox/\.git$
+^src/libs/libtopotoolbox/\.github$
+^src/libs/libtopotoolbox/\.clang-format$

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/libs/libtopotoolbox"]
+	path = src/libs/libtopotoolbox
+	url = https://github.com/TopoToolbox/libtopotoolbox

--- a/R/has_topotoolbox.R
+++ b/R/has_topotoolbox.R
@@ -3,6 +3,7 @@
 #' It is a dummy function that allows us to check for the inclusion of our Src C-functions.
 #'
 #' @export
-has_topotoolbox <- function(a){
-	return(.C(C_has_topotoolbox,as.integer(a)))
+has_topotoolbox <- function(){
+    a <- .C(C_wrap_has_topotoolbox,a=as.integer(0))$a
+    return(a == 1)
 }

--- a/man/has_topotoolbox.Rd
+++ b/man/has_topotoolbox.Rd
@@ -4,7 +4,7 @@
 \alias{has_topotoolbox}
 \title{has_topotoolbox}
 \usage{
-has_topotoolbox(a)
+has_topotoolbox()
 }
 \description{
 It is a dummy function that allows us to check for the inclusion of our Src C-functions.

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,0 +1,10 @@
+TT_DIR=libs/libtopotoolbox
+PKG_CPPFLAGS=-I$(TT_DIR)/include
+PKG_CFLAGS=-DTOPOTOOLBOX_STATICLIB
+PKG_LIBS=$(TT_DIR)/src/libtopotoolbox.a
+
+$(SHLIB): $(TT_DIR)/src/libtopotoolbox.a
+
+$(TT_DIR)/src/libtopotoolbox.a:
+	cd $(TT_DIR)/src && $(MAKE) libtopotoolbox.a \
+	  CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS)" AR="$(AR)" RANLIB="$(RANLIB)"

--- a/src/has_topotoolbox.c
+++ b/src/has_topotoolbox.c
@@ -1,3 +1,0 @@
-void has_topotoolbox(int *a) {
-  *a+1;
-}

--- a/src/has_topotoolbox.h
+++ b/src/has_topotoolbox.h
@@ -1,6 +1,0 @@
-#ifndef has_topotoolbox_h
-#define has_topotoolbox_h
-
-void has_topotoolbox(int *a);
-
-#endif

--- a/src/registerDynamicSymbol.c
+++ b/src/registerDynamicSymbol.c
@@ -3,10 +3,11 @@
 #include <R.h>
 #include <Rinternals.h>
 #include <R_ext/Rdynload.h>
-#include "has_topotoolbox.h"
+
+#include "topotoolboxr.h"
 
 static const R_CMethodDef cMethods[] = {
-   {"has_topotoolbox", (DL_FUNC) &has_topotoolbox,1},
+   {"wrap_has_topotoolbox", (DL_FUNC) &wrap_has_topotoolbox, 1},
    {NULL,NULL,0,NULL},
 };
 

--- a/src/topotoolboxr.c
+++ b/src/topotoolboxr.c
@@ -1,0 +1,5 @@
+#include <topotoolbox.h>
+
+void wrap_has_topotoolbox(int *a) {
+  *a = has_topotoolbox();
+}

--- a/src/topotoolboxr.h
+++ b/src/topotoolboxr.h
@@ -1,0 +1,6 @@
+#ifndef TOPOTOOLBOXR_H
+#define TOPOTOOLBOXR_H
+
+void wrap_has_topotoolbox(int *a);
+
+#endif // TOPOTOOLBOXR_H

--- a/tests/testthat/test-has_topotoolbox.R
+++ b/tests/testthat/test-has_topotoolbox.R
@@ -1,3 +1,3 @@
 test_that("has_topotoolbox equal 1?", {
-  expect_equal(has_topotoolbox(1)[[1]], c(1))
+  expect_true(has_topotoolbox())
 })


### PR DESCRIPTION
Fixes #4

This PR attempts to bind libtopotoolbox in a way that works for R and CRAN following the Writing R Extensions guide.

First, libtopotoolbox is added as a submodule of topotoolboxr. It is located in the src/libs/ directory. To clone topotoolboxr with the submodules, use

```
> git clone --recurse-submodules https://github.com/TopoToolbox/topotoolboxr
```

This ensures that the source code of libtopotoolbox is available within the topotoolboxr repository. The alternative is to insist that users have libtopotoolbox installed in a system-accessible location. Since libtopotoolbox is not available in any major system package manager, I have elected to include the source code.

Because R does not natively support CMake as a build system for libraries, I have created a POSIX-standard Makefile that simply compiles all of the C source files in libtopotoolbox/src/ into a static library. This is all R needs across platforms to be able to build a libtopotoolbox static library and then link it to the shared object file that it uses to access C functions from R.

As of now, we must use the TopoToolbox/libtopotoolbox#R-posix-makefile branch, for which the submodule is currently set up. If this is the route we decide to go, I will merge that branch into libtopotoolbox main so we can use it from here.

src/Makevars is used by R to control its build process. It sets up variables that R needs to find and link the libtopotoolbox library and then recursively calls make within the libtopotoolbox submodule to build the static library. R compiles everything in the src/ directory and links it with the libtopotoolbox static library via the PKG_LIBS variable.$PKG_CFLAGS is used to define the TOPOTOOLBOX_STATICLIB macro, which is necessary on Windows to get the right import declaration. PKG_CPPFLAGS points to the libtopotoolbox include directory so we can use the libtopotoolbox header file.

I have modified has_topotoolbox to use the corresponding libtopotoolbox function, which is wrapped here by
`wrap_has_topotoolbox` declared in src/topotoolboxr.h and defined in topotoolboxr.c.

src/registerDynamicSymbol.c is modified to use the new interface.

R/has_topotoolbox.R uses `wrap_has_topotoolbox` and has been modified so that it does not have any arguments like the libtopotoolbox version, and so it returns a Boolean.

tests/testthat/test-has_topotoolbox.R is modified to account for the new return type of has_topotoolbox

---

@FancyBirb: This is the result of my experiments with using submodules to distribute libtopotoolbox with topotoolboxr. It requires a Makefile in libtopotoolbox separate from that library's usual CMake build system, but it means everything can be built with a regular R installation across various platforms. Have a look at it and let me know if you have any questions. Hopefully once we have this structure in place, we can start building out more of the package's functionality.

This makes some of the changes in #7 obsolete, so it might be better to merge this one first and then fix the remaining `R CMD check` warnings.