### PR TITLE
Identify flats in the filled DEM during `flow_routing_d8_carve`

### DIFF
--- a/R/flow_routing_d8_carve.R
+++ b/R/flow_routing_d8_carve.R
@@ -15,8 +15,8 @@ flow_routing_d8_carve <- function(DEM){
   
   # Prepare inputs for flow routing based on raw DEM
   DEMf <- fillsinks(DEM)
+  FLATS <- identifyflats(DEMf)
   DIST <- gwdt(DEM)
-  FLATS <- identifyflats(DEM)
   
   demf <- get_grid_data(DEMf)
   dist <- get_grid_data(DIST)

--- a/tests/testthat/test-flow_routing_d8_carve.R
+++ b/tests/testthat/test-flow_routing_d8_carve.R
@@ -4,7 +4,7 @@ test_that("test-flow_routing_d8_carve.R creates a reference DEM and tests known 
   DEMr <- terra::rast(DEMm,crs="EPSG:25833")
   SouDir <- flow_routing_d8_carve(DEMr)
   expect_equal(as.vector(table(terra::values(SouDir$direction))),
-               c(8, 5, 1, 3, 1, 3, 1, 2, 1))
+               c(4, 6, 1, 4, 1, 4, 1, 3, 1))
   # Missing value handling
   DEMm[2,4] <- NA
   DEM <- terra::rast(DEMm ,crs="EPSG:25833")


### PR DESCRIPTION
This is the same issue that came up in https://github.com/TopoToolbox/topotoolboxr/pull/30, but I didn't catch it this time because I tested on a DEM that doesn't have any flats. This has now been manually tested on a DEM that does have flats by comparing to the pytopotoolbox version.

A snapshot test would come in handy here.

@ktlenz: I changed the test output values because I assumed you obtained them by running the code and copying its output. Let me know if you instead computed them by hand from what the flow directions should be on your test raster,  because then we need to make sure that this test case is behaving correctly.