### PR TITLE
Updated .Rbuildignore to prevent R CMD check notes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,6 +1,5 @@
 ^LICENSE\.md$
-^\.git$
-^\.github$
-^src/libs/libtopotoolbox/\.git$
-^src/libs/libtopotoolbox/\.github$
+(\.git$|\.git/)
+(\.github$|\.github/)
 ^src/libs/libtopotoolbox/\.clang-format$
+^src/libs/libtopotoolbox/src/libtopotoolbox.a$


### PR DESCRIPTION
This pull request resolves two notes generated by `devtools::check()` during package validation:

**Note 1**
checking if this is a source package ... NOTE  
Found the following apparent object files/libraries:  
src/libs/libtopotoolbox/src/libtopotoolbox.a  
Object files/libraries should not be included in a source package.

**Note 2**
checking for hidden files and directories ... NOTE  
Found the following hidden files and directories:  
src/libs/libtopotoolbox/test/snapshots/.git  
These were most likely included in error. See the 'Package structure'  
section in the 'Writing R Extensions' manual.

**Changes**
* Disabled creation of the static library file `libtopotoolbox.a` during package build to prevent its inclusion in the source package.
* Grouped`.Rbuildignore` statements to ignore all `.git` and `.github` directories throughout the repository.

The package now passes `devtools::check()` without generating the notes.

This pull request closes issue #48.