### PR TITLE
Install GDAL and PROJ explicitly on macos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,10 @@ jobs:
       - name: Install dependencies on macos
         if: matrix.os == 'macos-latest'
         run: brew install gdal proj
-      - name: Set PROJ_LIB
+      - name: Set PROJ_DATA
         if: matrix.os == 'macos-latest'
         run: |
-          echo "PROJ_LIB=$(brew --prefix proj)/share/proj" >> "$GITHUB_ENV"
+          echo "PROJ_DATA=$(brew --prefix proj)/share/proj" >> "$GITHUB_ENV"
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
Recently, we have noticed CI failures on `macos-latest` due to missing PROJ (#56). setup-r-dependencies says it can install system packages on Linux, but not Windows or macos. This adds an explicit installation of GDAL and PROJ using Homebrew on macos.