### PR TITLE
Pin r-lib/actions to a SHA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,12 +24,12 @@ jobs:
         run: |
           echo "PROJ_DATA=$(brew --prefix proj)/share/proj" >> "$GITHUB_ENV"
       - name: Set up R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e
         with:
           r-version: release
       - name: Install dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@a51a8012b0aab7c32ef9d19bf54da93f3254335e
         with:
           extra-packages: any::rcmdcheck
       - name: Build and check
-        uses: r-lib/actions/check-r-package@v2
+        uses: r-lib/actions/check-r-package@a51a8012b0aab7c32ef9d19bf54da93f3254335e


### PR DESCRIPTION
Closes #71

The v2 actions were already updated for the Node 20 -> 24 transition, but it is still a good idea to pin the hash, especially because r-lib/actions moves the v2 tag around.